### PR TITLE
Add manylinux2014 Dockerfile for CPU builds

### DIFF
--- a/images/Dockerfile.manylinux2014.cpu
+++ b/images/Dockerfile.manylinux2014.cpu
@@ -1,0 +1,28 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+
+LABEL maintainer="Subin Modeel <smodeel@redhat.com>"
+
+# Copy and run each install script one at a time for better layer caching.
+
+COPY install/install_rpm_packages.sh /install/
+RUN /install/install_rpm_packages.sh
+
+COPY install/install_golang.sh /install/
+RUN /install/install_golang.sh
+
+COPY install/install_proto3.sh /install/
+RUN /install/install_proto3.sh
+
+COPY install/install_buildifier.sh /install/
+RUN /install/install_buildifier.sh
+
+COPY install/install_bazel.sh /install/
+RUN /install/install_bazel.sh
+
+# manylinux2014 - devtoolset-7 and python3.6
+COPY install/install_pip_packages.sh /install/
+RUN source scl_source enable devtoolset-7 rh-python36 && \
+    /install/install_pip_packages.sh
+
+# Set up the master bazelrc configuration file.
+COPY install/bazelrc /etc/bazel.bazelrc

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,16 @@
+# Dockerfiles for TensorFlow builds
+
+## manylinux2014 builds
+Run the below commands to create manylinux2014 build environment.    
+```
+docker build -t build/manylinux2014 -f Dockerfile.manylinux2014.cpu .
+docker run -it build/manylinux2014:latest /bin/bash
+
+Run the below commands to build TF.  
+```
+source scl_source enable devtoolset-7 rh-python36
+git clone --branch=r2.1 --depth=1 https://github.com/tensorflow/tensorflow.git
+cd tensorflow/
+./configure
+bazel build -c opt --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --verbose_failures //tensorflow/tools/pip_package:build_pip_package
+```

--- a/images/install/install_golang.sh
+++ b/images/install/install_golang.sh
@@ -18,5 +18,5 @@ set -ex
 
 GOLANG_URL="https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz"
 
-sudo mkdir -p /usr/local
-wget -q -O - "${GOLANG_URL}" | sudo tar -C /usr/local -xz
+mkdir -p /usr/local
+wget -q -O - "${GOLANG_URL}" | tar -C /usr/local -xz

--- a/images/install/install_pip_packages.sh
+++ b/images/install/install_pip_packages.sh
@@ -16,93 +16,115 @@
 
 set -e
 
+PYTHON_CMD="python3"
+
+
+# Determine OS
+UNAME=$(uname | tr "[:upper:]" "[:lower:]")
+# If Linux
+if [ "$UNAME" == "linux" ]; then
+    # If redhat-release file is available use it to identify distribution
+    if [ -f /etc/redhat-release ]; then
+        PYTHON_CMD="python"
+        # Note: 
+        # We need to run>scl enable devtoolset-7 rh-python36
+        # to use gcc-7 and python3.6. Adding it here will exit the script.
+        # So we add in the Dockerfile.
+    fi
+    if [ -f /etc/lsb-release ]; then
+        PYTHON_CMD="python3"
+    fi
+fi
+
+# gcc is installed via install_[deb|rpm]_packages.sh
+gcc --version
 echo "Python and pip versions:"
-python3 --version
-python3 -m pip --version
+$PYTHON_CMD --version
+$PYTHON_CMD -m pip --version
 echo
 
 # Get the latest version of pip so it recognize manylinux2010
-python3 -m pip install --upgrade pip
+$PYTHON_CMD -m pip install --upgrade pip
 
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 
 # wheel==0.32.0 breaks auditwheel:
 # https://github.com/pypa/auditwheel/issues/102
-python3 -m pip install --upgrade wheel>=0.32.1
+$PYTHON_CMD -m pip install --upgrade wheel>=0.32.1
 
 # Install last working version of setuptools. This must happen before we install
 # absl-py, which uses install_requires notation introduced in setuptools 20.5.
-python3 -m pip install --upgrade setuptools>=39.1.0
+$PYTHON_CMD -m pip install --upgrade setuptools>=39.1.0
 
 # Install six and future.
-python3 -m pip install --upgrade six>=1.12.0
-python3 -m pip install --upgrade future>=0.17.1
+$PYTHON_CMD -m pip install --upgrade six>=1.12.0
+$PYTHON_CMD -m pip install --upgrade future>=0.17.1
 
 # Install absl-py.
-python3 -m pip install --upgrade absl-py
+$PYTHON_CMD -m pip install --upgrade absl-py
 
 # Install werkzeug.
-python3 -m pip install --upgrade werkzeug==0.11.10
+$PYTHON_CMD -m pip install --upgrade werkzeug==0.11.10
 
 # Install bleach. html5lib will be picked up as a dependency.
-python3 -m pip install --upgrade bleach==2.0.0
+$PYTHON_CMD -m pip install --upgrade bleach==2.0.0
 
 # Install markdown.
-python3 -m pip install --upgrade markdown==2.6.8
+$PYTHON_CMD -m pip install --upgrade markdown==2.6.8
 
 # Install protobuf.
-python3 -m pip install --upgrade protobuf==3.6.1
+$PYTHON_CMD -m pip install --upgrade protobuf==3.6.1
 
 # Remove obsolete version of six, which can sometimes confuse virtualenv.
-rm -rf /usr/lib/python3/dist-packages/six*
+rm -rf /usr/lib/$PYTHON_CMD/dist-packages/six*
 
-python3 -m pip install --upgrade numpy==1.14.5
+$PYTHON_CMD -m pip install --upgrade numpy==1.14.5
 
-python3 -m pip install scipy==1.4.1
+$PYTHON_CMD -m pip install scipy==1.4.1
 
-python3 -m pip install scikit-learn==0.18.1
+$PYTHON_CMD -m pip install scikit-learn==0.18.1
 
 # pandas required by `inflow`
-python3 -m pip install pandas==0.19.2
+$PYTHON_CMD -m pip install pandas==0.19.2
 
 # Benchmark tests require the following:
-python3 -m pip install psutil==5.6.3
-python3 -m pip install py-cpuinfo
+$PYTHON_CMD -m pip install psutil==5.6.3
+$PYTHON_CMD -m pip install py-cpuinfo
 
 # pylint tests require the following:
-python3 -m pip install pylint==1.6.4
+$PYTHON_CMD -m pip install pylint==1.6.4
 
 # pycodestyle tests require the following:
-python3 -m pip install pycodestyle
+$PYTHON_CMD -m pip install pycodestyle
 
-python3 -m pip install portpicker
+$PYTHON_CMD -m pip install portpicker
 
 # TensorFlow Serving integration tests require the following:
-python3 -m pip install grpcio
+$PYTHON_CMD -m pip install grpcio
 
 # Eager-to-graph execution needs astor, gast and termcolor:
-python3 -m pip install --upgrade astor
-python3 -m pip install --upgrade gast
-python3 -m pip install --upgrade termcolor
+$PYTHON_CMD -m pip install --upgrade astor
+$PYTHON_CMD -m pip install --upgrade gast
+$PYTHON_CMD -m pip install --upgrade termcolor
 
 # Keras
-python3 -m pip install --upgrade keras_applications>=1.0.8 --no-deps
-python3 -m pip install --upgrade keras_preprocessing>=1.1.0 --no-deps
-python3 -m pip install --upgrade h5py>=2.8.0
+$PYTHON_CMD -m pip install --upgrade keras_applications>=1.0.8 --no-deps
+$PYTHON_CMD -m pip install --upgrade keras_preprocessing>=1.1.0 --no-deps
+$PYTHON_CMD -m pip install --upgrade h5py>=2.8.0
 
 # Estimator
-python3 -m pip install tf-estimator-nightly --no-deps
+$PYTHON_CMD -m pip install tf-estimator-nightly --no-deps
 
 # Tensorboard
-python3 -m pip install --upgrade google-auth>=1.6.3 google-auth-oauthlib>=0.4.1 werkzeug>=0.11.15
-python3 -m pip install tb-nightly --no-deps
+$PYTHON_CMD -m pip install --upgrade google-auth>=1.6.3 google-auth-oauthlib>=0.4.1 werkzeug>=0.11.15
+$PYTHON_CMD -m pip install tb-nightly --no-deps
 
 # Argparse
-python3 -m pip install --upgrade argparse
+$PYTHON_CMD -m pip install --upgrade argparse
 
-python3 -m pip install auditwheel>=2.0.0
+$PYTHON_CMD -m pip install auditwheel>=2.0.0
 
 echo "Installed python package versions:"
-python3 -m pip freeze
+$PYTHON_CMD -m pip freeze
 

--- a/images/install/install_rpm_packages.sh
+++ b/images/install/install_rpm_packages.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Usage:
+#     ./install_rpm_packages
+
+set -e
+
+# Note:
+# Don't run >yum update for manylinux2014 Image
+# https://github.com/sclorg/centos-release-scl
+# pypa uses centos-release-scl-rh
+# Don't run >yum install -y centos-release-scl
+
+# gpg java-headless procps are not available
+INSTALL_PKGS="autoconf \
+    automake \
+    binutils \
+    bsdtar \
+    bzip2 \
+    c-ares \
+    c-ares-devel \
+    clang \
+    cmake \
+    cpuid \
+    curl \
+    devtoolset-7 \
+    dmidecode \
+    file \
+    findutils \
+    freetype-devel \
+    gcc \
+    gcc-c++ \
+    gdb \
+    gettext \
+    git \
+    giflib-devel \
+    glibc-devel \
+    gnupg2 \
+    groff-base \
+    gzip \
+    java-1.8.0-openjdk \
+    java-1.8.0-openjdk-devel \
+    kernel-devel \
+    libpng12-devel \
+    libtool \
+    libxml2 \
+    libxml2-devel \
+    libxslt \
+    libxslt-devel \
+    make \
+    mlocate \
+    openssl-devel \
+    patch \
+    pciutils \
+    perf \
+    protobuf-compiler \
+    python27 \
+    rh-python35 \
+    rh-python36 \
+    rsync \
+    scl-utils \
+    sqlite \
+    swig \
+    tar \
+    tree \
+    unzip \
+    wget \
+    which \
+    x86info  \
+    yum-utils \
+    zeromq3-devel \
+    zip \
+    zlib-devel"
+
+yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS
+#rpm -V $INSTALL_PKGS
+yum -y clean all --enablerepo='*'
+
+# populate the database
+updatedb


### PR DESCRIPTION
This PR adds manylinux2014 Dockerfile and the changes needed to install rpm packages.
Summary of changes:
- `sudo` command was removed from `install_golang.sh`.
- added `Dockerfile.manylinux2014.cpu`.
- added `install_rpm_packages.sh`.
- modified `install_pip_packages.sh` to use python36 in centos7 Image.

