### PR TITLE
ppc64le dockerfiles used for TF builds

### DIFF
--- a/images/ppc64le/cpu/Dockerfile.manylinux_2014
+++ b/images/ppc64le/cpu/Dockerfile.manylinux_2014
@@ -1,0 +1,41 @@
+#docker build -f Dockerfile.manylinux_2014 -t ibmcom/tensorflow-ppc64le:devel-manylinux2014 .
+FROM quay.io/pypa/manylinux2014_ppc64le
+
+ARG BAZEL_VERSION=1.2.1
+ENV PATH=/opt/python/cp36-cp36m/bin:$PATH
+
+RUN yum install -y java-11-openjdk-devel wget zip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /
+RUN mkdir /bazel && \
+    cd /bazel && \
+    curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip && \
+    unzip bazel-$BAZEL_VERSION-dist.zip && \
+    BAZEL_LINKLIBS=-l%:libstdc++.a EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh && \
+    cp output/bazel /usr/local/bin/ && \
+    cd / && \
+    rm -rf /bazel
+
+RUN pip install six numpy wheel setuptools mock
+RUN pip install keras_applications keras_preprocessing --no-deps
+
+#To build in OSU's Jenkins environment
+#From https://github.com/osuosl/osl-dockerfiles/blob/master/centos-ppc64le/Dockerfile#L14-L31
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=10000
+ARG gid=10000
+ARG JENKINS_AGENT_HOME=/home/${user}
+
+ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+
+RUN groupadd -g ${gid} ${group} && \
+    useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
+
+# setup sudo
+RUN yum install -y sudo && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    echo "jenkins ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/images/ppc64le/cpu/Dockerfile.manylinux_2014
+++ b/images/ppc64le/cpu/Dockerfile.manylinux_2014
@@ -1,7 +1,7 @@
 #docker build -f Dockerfile.manylinux_2014 -t ibmcom/tensorflow-ppc64le:devel-manylinux2014 .
 FROM quay.io/pypa/manylinux2014_ppc64le
 
-ARG BAZEL_VERSION=1.2.1
+ARG BAZEL_VERSION=2.0.0
 ENV PATH=/opt/python/cp36-cp36m/bin:$PATH
 
 RUN yum install -y java-11-openjdk-devel wget zip && \

--- a/images/ppc64le/gpu/Dockerfile.manylinux_2014.cuda10_1
+++ b/images/ppc64le/gpu/Dockerfile.manylinux_2014.cuda10_1
@@ -1,0 +1,63 @@
+#docker build -f Dockerfile.manylinux_2014.cuda10_1 -t ibmcom/tensorflow-ppc64le:gpu-devel-manylinux2014 .
+FROM ibmcom/tensorflow-ppc64le:devel-manylinux2014
+
+#Copied from https://gitlab.com/nvidia/container-images/cuda-ppc64le/blob/centos7/10.1/base/Dockerfile
+
+RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel7/ppc64le/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
+
+COPY cuda.repo /etc/yum.repos.d/cuda.repo
+
+ENV CUDA_VERSION 10.1.243
+
+ENV CUDA_PKG_VERSION 10-1-$CUDA_VERSION-1
+RUN yum install -y \
+        cuda-cudart-$CUDA_PKG_VERSION && \
+    ln -s cuda-10.1 /usr/local/cuda && \
+    rm -rf /var/cache/yum/*
+
+# nvidia-docker 1.0
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.1"
+
+# Copied from https://gitlab.com/nvidia/container-images/cuda-ppc64le/blob/centos7/10.1/runtime/Dockerfile
+
+RUN yum install -y \
+        cuda-libraries-$CUDA_PKG_VERSION && \
+    rm -rf /var/cache/yum/*
+
+# Copied from https://gitlab.com/nvidia/container-images/cuda-ppc64le/blob/centos7/10.1/devel/Dockerfile
+
+RUN yum install -y \
+        cuda-libraries-dev-$CUDA_PKG_VERSION \
+        cuda-nvml-dev-$CUDA_PKG_VERSION \
+        cuda-minimal-build-$CUDA_PKG_VERSION \
+        cuda-command-line-tools-$CUDA_PKG_VERSION && \
+    rm -rf /var/cache/yum/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+
+# Copied from https://gitlab.com/nvidia/container-images/cuda-ppc64le/blob/centos7/10.1/devel/cudnn7/Dockerfile
+
+ENV CUDNN_VERSION 7.6.5.32
+LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
+
+# cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
+RUN CUDNN_DOWNLOAD_SUM=97b2faf73eedfc128f2f5762784d21467a95b2d5ba719825419c058f427cbf56 && \
+    curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-ppc64le-v7.6.5.32.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-ppc64le-v7.6.5.32.tgz" | sha256sum -c - && \
+    tar --no-same-owner -xzf cudnn-10.1-linux-ppc64le-v7.6.5.32.tgz -C /usr/local && \
+    rm cudnn-10.1-linux-ppc64le-v7.6.5.32.tgz && \
+    ldconfig

--- a/images/ppc64le/gpu/cuda.repo
+++ b/images/ppc64le/gpu/cuda.repo
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=http://developer.download.nvidia.com/compute/cuda/repos/rhel7/ppc64le
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA


### PR DESCRIPTION
ppc64le/cpu/Dockerfile.manylinux_2014 extends from the quay.io/pypa/manylinux2014_ppc64le
docker image and installs java, bazel (from source), and the minimal required
pip packages to build TensorFlow

It also adds the jenkins userid necessary to work with Oregon State University's
Open Source Lab jenkins environment.

ppc64le/gpu/Dockerfile.manylinux_2014.cuda10_1 extends from the cpu image and adds
CUDA 10.1 and cuDNN 7.6