### PR TITLE
Updated bazel version in the ppc64le image

### DIFF
--- a/ppc64le_builds/images/cpu/Dockerfile.manylinux_2014
+++ b/ppc64le_builds/images/cpu/Dockerfile.manylinux_2014
@@ -1,7 +1,7 @@
 #docker build -f Dockerfile.manylinux_2014 -t ibmcom/tensorflow-ppc64le:devel-manylinux2014 .
 FROM quay.io/pypa/manylinux2014_ppc64le
 
-ARG BAZEL_VERSION=2.0.0
+ARG BAZEL_VERSION=3.7.2
 ENV PATH=/opt/python/cp36-cp36m/bin:$PATH
 
 RUN yum install -y java-11-openjdk-devel wget zip && \


### PR DESCRIPTION
Updated cpu only Docker image for ppc64le to build and install the bazel version needed by latest Tensorflow.