### PR TITLE
Pylint and sanity_check

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: pylint
         run: |
           /bin/bash -c "add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8 && python3.8 -m pip install pylint==2.7.4 \
-          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && pylint -j4  ./tensorflow/"
+          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && pylint -j$(nproc)  ./tensorflow/"
   ci-sanity:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: tensorflow/tensorflow
-      - name: Featch PR
+      - name: Fetch PR
         run: | 
           git fetch origin pull/48371/head:48371
           git checkout 48371
@@ -35,8 +35,8 @@ jobs:
           --output "type=docker" \
           --platform linux/amd64 \
           tensorflow/tools/dockerfiles/ -f tensorflow/tools/dockerfiles/dockerfiles/devel-cpu.Dockerfile \
-          --tag tensorflow/tensorflow:devel
+          --tag tensorflow:devel
       - name: CI Santity
         run: |
-          docker run -v ${PWD}:/tensorflow -w /tensorflow tensorflow/tensorflow:devel \
+          docker run -v ${PWD}:/tensorflow -w /tensorflow tensorflow:devel \
           tensorflow/tools/ci_build/ci_sanity.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,7 +13,7 @@ jobs:
         apt-get install --assume-yes python3.8
     - name: pylint-install
       run:  |
-        python3.8 -m pip install pylint==2.7.4 
+        python3.8 -m pip install pylint==2.7.4 numpy~=1.19.2
     - name: branch-checkout
       working-directory: /tensorflow_src
       run: |
@@ -33,7 +33,7 @@ jobs:
         add-apt-repository ppa:deadsnakes/ppa -y
         apt-get install --assume-yes python3.8
     - name: pylint-install
-      run:  python3.8 -m pip install pylint==2.7.4 
+      run:  python3.8 -m pip install pylint==2.7.4 numpy~=1.19.2
     - name: branch-checkout
       working-directory: /tensorflow_src
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,10 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-      - uses: actions/checkout@v2
-      - with:
+        uses: actions/checkout@v2
+        with:
           repository: tensorflow/tensorflow
-      - run: | 
+      - name: Featch PR
+        run: | 
           git fetch origin pull/48371/head:48371
           git checkout 48371
         

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,7 +21,7 @@ jobs:
         git checkout pylint_silence
     - name: pylint
       run: |
-       python3.8 -m pylint -j$(nproc)  ./tensorflow/"
+        python3.8 -m pylint -j$(nproc) tensorflow
   ci-sanity:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,16 +7,31 @@ jobs:
     container:
       image: tensorflow/tensorflow:devel
     steps:
-      - name: pylint
-        run: |
-          /bin/bash -c "add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8 && python3.8 -m pip install pylint==2.7.4 \
-          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && pylint -j$(nproc)  ./tensorflow/"
+      - name: python3.8
+        shell: bash
+        run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8
+      - name: pylint-install
+        shell: bash
+        run:  python3.8 -m pip install pylint==2.7.4 
+      - name: branch-checkout
+          shell: bash
+          run: cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence 
+      . name: pylint
+          run: |
+          python3.8 -m pylint -j$(nproc)  ./tensorflow/"
   ci-sanity:
     runs-on: ubuntu-latest
     container:
       image: tensorflow/tensorflow:devel
     steps:
-      - name: ci_santy.sh
+      - name: python3.8
+        shell: bash
+        run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8
+      - name: pylint-install
+        shell: bash
+        run: python3.8 -m pip install pylint==2.7.4 
+      - name: branch-checkout
+          shell: bash
+          run: cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence 
         run: |
-          /bin/bash -c "add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8 && python3.8 -m pip install pylint==2.7.4 \
-          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && ./tensorflow/tools/ci_build/ci_sanity.sh --pylint"
+          ./tensorflow/tools/ci_build/ci_sanity.sh --pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,14 +8,18 @@ jobs:
       image: tensorflow/tensorflow:devel
     steps:
       - name: python3.8
-        shell: bash
-        run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8
+        run: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt-get install --assume-yes python3.8
       - name: pylint-install
         shell: bash
         run:  python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
           shell: bash
-          run: cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence 
+          run: |
+          cd /tensorflow_src
+          git fetch origin pull/48294/head:pylint_silence
+          git checkout pylint_silence
       . name: pylint
           run: |
           python3.8 -m pylint -j$(nproc)  ./tensorflow/"
@@ -25,13 +29,18 @@ jobs:
       image: tensorflow/tensorflow:devel
     steps:
       - name: python3.8
-        shell: bash
-        run: add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8
+        run: |
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt-get install --assume-yes python3.8
       - name: pylint-install
         shell: bash
-        run: python3.8 -m pip install pylint==2.7.4 
+        run:  python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
           shell: bash
-          run: cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence 
-        run: |
+          run: |
+          cd /tensorflow_src
+          git fetch origin pull/48294/head:pylint_silence
+          git checkout pylint_silence
+        name: ci_sanity.sh
+          run: |
           ./tensorflow/tools/ci_build/ci_sanity.sh --pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,44 +2,40 @@ name: ci
 
 on: [push, pull_request]
 jobs:
-  pylint-sanity:
+  buildx:
     runs-on: ubuntu-latest
-    container:
-      image: tensorflow/tensorflow:devel
     steps:
-    - name: python3.8
-      run: |
-        add-apt-repository ppa:deadsnakes/ppa -y
-        apt-get install --assume-yes python3.8
-    - name: pylint-install
-      run:  |
-        python3.8 -m pip install pylint==2.7.4 numpy~=1.19.2
-    - name: branch-checkout
-      working-directory: /tensorflow_src
-      run: |
-        git fetch origin pull/48294/head:pylint_silence
-        git checkout pylint_silence
-    - name: pylint
-      working-directory: /tensorflow_src
-      run: |
-        python3.8 -m pylint -j$(nproc) tensorflow
-  ci-sanity:
-    runs-on: ubuntu-latest
-    container:
-      image: tensorflow/tensorflow:devel
-    steps:
-    - name: python3.8
-      run: |
-        add-apt-repository ppa:deadsnakes/ppa -y
-        apt-get install --assume-yes python3.8
-    - name: pylint-install
-      run:  python3.8 -m pip install pylint==2.7.4 numpy~=1.19.2
-    - name: branch-checkout
-      working-directory: /tensorflow_src
-      run: |
-        git fetch origin pull/48294/head:pylint_silence
-        git checkout pylint_silence
-    - name: ci_sanity.sh
-      working-directory: /tensorflow_src
-      run: |
-        ./tensorflow/tools/ci_build/ci_sanity.sh --pylint
+      - name: Checkout
+      - uses: actions/checkout@v2
+      - with:
+          repository: tensorflow/tensorflow
+      - run: | 
+          git fetch origin pull/48371/head:48371
+          git checkout 48371
+        
+      -
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Build Image
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --output "type=docker" \
+          --platform linux/amd64 \
+          tensorflow/tools/dockerfiles/ -f tensorflow/tools/dockerfiles/dockerfiles/devel-cpu.Dockerfile \
+          --tag tensorflow/tensorflow:devel
+      - name: CI Santity
+        run: |
+          docker run -v ${PWD}:/tensorflow -w /tensorflow tensorflow/tensorflow:devel \
+          tensorflow/tools/ci_build/ci_sanity.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,38 +7,37 @@ jobs:
     container:
       image: tensorflow/tensorflow:devel
     steps:
-      - name: python3.8
-        run: |
-          add-apt-repository ppa:deadsnakes/ppa -y
-          apt-get install --assume-yes python3.8
-      - name: pylint-install
-        run:  |
-          python3.8 -m pip install pylint==2.7.4 
-      - name: branch-checkout
-        run: |
-          cd /tensorflow_src
-          git fetch origin pull/48294/head:pylint_silence
-          git checkout pylint_silence
-      . name: pylint
-          run: |
-            python3.8 -m pylint -j$(nproc)  ./tensorflow/"
+    - name: python3.8
+      run: |
+        add-apt-repository ppa:deadsnakes/ppa -y
+        apt-get install --assume-yes python3.8
+    - name: pylint-install
+      run:  |
+        python3.8 -m pip install pylint==2.7.4 
+    - name: branch-checkout
+      run: |
+        cd /tensorflow_src
+        git fetch origin pull/48294/head:pylint_silence
+        git checkout pylint_silence
+    - name: pylint
+      run: |
+       python3.8 -m pylint -j$(nproc)  ./tensorflow/"
   ci-sanity:
     runs-on: ubuntu-latest
     container:
       image: tensorflow/tensorflow:devel
     steps:
-      - name: python3.8
-        run: |
-          add-apt-repository ppa:deadsnakes/ppa -y
-          apt-get install --assume-yes python3.8
-      - name: pylint-install
-        shell: bash
-        run:  python3.8 -m pip install pylint==2.7.4 
-      - name: branch-checkout
-          run: |
-            cd /tensorflow_src
-            git fetch origin pull/48294/head:pylint_silence
-            git checkout pylint_silence
-        name: ci_sanity.sh
-          run: |
-            ./tensorflow/tools/ci_build/ci_sanity.sh --pylint
+    - name: python3.8
+      run: |
+        add-apt-repository ppa:deadsnakes/ppa -y
+        apt-get install --assume-yes python3.8
+    - name: pylint-install
+      run:  python3.8 -m pip install pylint==2.7.4 
+    - name: branch-checkout
+      run: |
+        cd /tensorflow_src
+        git fetch origin pull/48294/head:pylint_silence
+        git checkout pylint_silence
+    - name: ci_sanity.sh
+      run: |
+        ./tensorflow/tools/ci_build/ci_sanity.sh --pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,16 +12,16 @@ jobs:
           add-apt-repository ppa:deadsnakes/ppa -y
           apt-get install --assume-yes python3.8
       - name: pylint-install
-        shell: bash
-        run:  python3.8 -m pip install pylint==2.7.4 
+        run:  |
+          python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
-          run: |
+        run: |
           cd /tensorflow_src
           git fetch origin pull/48294/head:pylint_silence
           git checkout pylint_silence
       . name: pylint
           run: |
-          python3.8 -m pylint -j$(nproc)  ./tensorflow/"
+            python3.8 -m pylint -j$(nproc)  ./tensorflow/"
   ci-sanity:
     runs-on: ubuntu-latest
     container:
@@ -36,9 +36,9 @@ jobs:
         run:  python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
           run: |
-          cd /tensorflow_src
-          git fetch origin pull/48294/head:pylint_silence
-          git checkout pylint_silence
+            cd /tensorflow_src
+            git fetch origin pull/48294/head:pylint_silence
+            git checkout pylint_silence
         name: ci_sanity.sh
           run: |
-          ./tensorflow/tools/ci_build/ci_sanity.sh --pylint
+            ./tensorflow/tools/ci_build/ci_sanity.sh --pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,7 +15,6 @@ jobs:
         shell: bash
         run:  python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
-          shell: bash
           run: |
           cd /tensorflow_src
           git fetch origin pull/48294/head:pylint_silence
@@ -36,7 +35,6 @@ jobs:
         shell: bash
         run:  python3.8 -m pip install pylint==2.7.4 
       - name: branch-checkout
-          shell: bash
           run: |
           cd /tensorflow_src
           git fetch origin pull/48294/head:pylint_silence

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,22 @@
+name: ci
+
+on: [push, pull_request]
+jobs:
+  pylint-sanity:
+    runs-on: ubuntu-latest
+    container:
+      image: tensorflow/tensorflow:devel
+    steps:
+      - name: pylint
+        run: |
+          /bin/bash -c "add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8 && python3.8 -m pip install pylint==2.7.4 \
+          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && pylint -j4  ./tensorflow/"
+  ci-sanity:
+    runs-on: ubuntu-latest
+    container:
+      image: tensorflow/tensorflow:devel
+    steps:
+      - name: ci_santy.sh
+        run: |
+          /bin/bash -c "add-apt-repository ppa:deadsnakes/ppa -y && apt-get install --assume-yes python3.8 && python3.8 -m pip install pylint==2.7.4 \
+          && cd /tensorflow_src && git fetch origin pull/48294/head:pylint_silence && git checkout pylint_silence && ./tensorflow/tools/ci_build/ci_sanity.sh --pylint"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,11 +15,12 @@ jobs:
       run:  |
         python3.8 -m pip install pylint==2.7.4 
     - name: branch-checkout
+      working-directory: /tensorflow_src
       run: |
-        cd /tensorflow_src
         git fetch origin pull/48294/head:pylint_silence
         git checkout pylint_silence
     - name: pylint
+      working-directory: /tensorflow_src
       run: |
         python3.8 -m pylint -j$(nproc) tensorflow
   ci-sanity:
@@ -34,10 +35,11 @@ jobs:
     - name: pylint-install
       run:  python3.8 -m pip install pylint==2.7.4 
     - name: branch-checkout
+      working-directory: /tensorflow_src
       run: |
-        cd /tensorflow_src
         git fetch origin pull/48294/head:pylint_silence
         git checkout pylint_silence
     - name: ci_sanity.sh
+      working-directory: /tensorflow_src
       run: |
         ./tensorflow/tools/ci_build/ci_sanity.sh --pylint


### PR DESCRIPTION
This is a github Action to support and test https://github.com/tensorflow/tensorflow/pull/48294 and our Gitter thread with /cc @perfinion @angerson. It has two job flat `pylint` and `ci_sanity.sh` in `tensorflow/tensorflow:devel`.

As you can see from the Action log `pylint` behavior is different if we let it to explore the module itself or if we push a list of python files with `find` as in our `ci_sanity.sh` approach.

See also:
https://stackoverflow.com/questions/36873096/run-pylint-for-all-python-files-in-a-directory-and-all-subdirectories
https://pylint.readthedocs.io/en/latest/user_guide/run.html