### PR TITLE
[Go] Remove note about feature warnings

### DIFF
--- a/golang_install_guide/README.md
+++ b/golang_install_guide/README.md
@@ -102,15 +102,8 @@ go run hello_tf.go
 
 The command outputs: `Hello from TensorFlow version *number*`
 
-Success: TensorFlow for Go has been configured.
+### Success: TensorFlow for Go has been configured.
 
-The program may generate the following warning messages, which you can ignore:
-
-```
-W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library
-wasn't compiled to use *Type* instructions, but these are available on your
-machine and could speed up CPU computations.
-```
 
 ## Build from source
 


### PR DESCRIPTION
These are info messages since https://github.com/tensorflow/tensorflow/commit/8a8eb5ea1446fbbf6716206ead944802454a1fb4 and the info message is self-explanatory