### PR TITLE
Add an execution log

### DIFF
--- a/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
@@ -32,5 +32,11 @@ build --copt=-mavx --host_copt=-mavx
 # See https://docs.bazel.build/versions/main/skylark/performance.html#performance-profiling
 build --profile=/tf/pkg/profile.json
 
+# Store the execution log binary in the mounted artifact directory.
+# This log is recommended to debug missing cache hit on the same machine and on different machines.
+# See more at step 2 and 4 in:
+# https://docs.bazel.build/versions/main/remote-caching-debug.html
+build --execution_log_binary_file=/tf/pkg/exec_cpu.log
+
 # Use the NVCC toolchain to compile for manylinux2010
 build --crosstool_top=@ubuntu18.04-gcc7_manylinux2010-cuda11.2-cudnn8.1-tensorrt7.2_config_cuda//crosstool:toolchain

--- a/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
@@ -34,7 +34,7 @@ build --profile=/tf/pkg/profile.json
 
 # Store the execution log binary in the mounted artifact directory.
 # This log is recommended to debug missing cache hit on the same machine and on different machines.
-# See more at step 2 and 4 in:
+# See more at step 2 and 3c in:
 # https://docs.bazel.build/versions/main/remote-caching-debug.html
 build --execution_log_binary_file=/tf/pkg/exec_cpu.log
 

--- a/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -32,6 +32,12 @@ build --copt=-mavx --host_copt=-mavx
 # See https://docs.bazel.build/versions/main/skylark/performance.html#performance-profiling
 build --profile=/tf/pkg/profile.json
 
+# Store the execution log binary in the mounted artifact directory.
+# This log is recommended to debug missing cache hit on the same machine and on different machines.
+# See more at step 2 and 4 in:
+# https://docs.bazel.build/versions/main/remote-caching-debug.html
+build --execution_log_binary_file=/tf/pkg/exec_cuda.log
+
 # CUDA: Set up compilation CUDA version and paths
 build --@local_config_cuda//:enable_cuda
 build --repo_env TF_NEED_CUDA=1

--- a/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -34,7 +34,7 @@ build --profile=/tf/pkg/profile.json
 
 # Store the execution log binary in the mounted artifact directory.
 # This log is recommended to debug missing cache hit on the same machine and on different machines.
-# See more at step 2 and 4 in:
+# See more at step 2 and 3c in:
 # https://docs.bazel.build/versions/main/remote-caching-debug.html
 build --execution_log_binary_file=/tf/pkg/exec_cuda.log
 

--- a/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -36,7 +36,7 @@ build --profile=/tf/pkg/profile.json
 # This log is recommended to debug missing cache hit on the same machine and on different machines.
 # See more at step 2 and 3c in:
 # https://docs.bazel.build/versions/main/remote-caching-debug.html
-build --execution_log_binary_file=/tf/pkg/exec_cuda.log
+build --execution_log_binary_file=/tf/pkg/exec_gpu.log
 
 # CUDA: Set up compilation CUDA version and paths
 build --@local_config_cuda//:enable_cuda


### PR DESCRIPTION
This will store the executioin log in the mounted volume `/tf/pkg/` like the new stored build profile.
This will help debug cache misses on subsequent CI builds on the same or different commit and on local dev machines.

See more at step 2 and 3c in:
https://docs.bazel.build/versions/main/remote-caching-debug.html