### PR TITLE
Fix Build issue from `python_include` - Do Not Merge (Delete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .*.swp
 *~
+.vscode/
+.idea/**
+.DS_Store
 
 __pycache__
 *.pyo

--- a/tf_sig_build_dockerfiles/Dockerfile
+++ b/tf_sig_build_dockerfiles/Dockerfile
@@ -33,7 +33,7 @@ RUN /setup.sources.sh && /setup.packages.sh /devel.packages.txt && /setup.cuda.s
 # - bazelisk: always use the correct bazel version
 # - buildifier: clean bazel build deps
 # - buildozer: clean bazel build deps
-RUN git clone --branch v1.3.0 https://github.com/bats-core/bats-core.git && bats-core/install.sh /usr/local && rm -rf bats-core
+RUN git clone --branch v1.5.0 https://github.com/bats-core/bats-core.git && bats-core/install.sh /usr/local && rm -rf bats-core
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 -O /usr/local/bin/bazel && chmod +x /usr/local/bin/bazel
 RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier -O /usr/local/bin/buildifier && chmod +x /usr/local/bin/buildifier
 RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildozer -O /usr/local/bin/buildozer && chmod +x /usr/local/bin/buildozer

--- a/tf_sig_build_dockerfiles/devel.packages.txt
+++ b/tf_sig_build_dockerfiles/devel.packages.txt
@@ -33,6 +33,7 @@ clang-format
 curl
 ffmpeg
 git
+jq
 libcurl3-dev
 libcurl4-openssl-dev
 libfreetype6-dev

--- a/tf_sig_build_dockerfiles/devel.usertools/get_test_list.sh
+++ b/tf_sig_build_dockerfiles/devel.usertools/get_test_list.sh
@@ -5,4 +5,4 @@
 # Hides all extra output and always exits with success for now.
 OUTPUT=$1
 shift
-"$@" --check_tests_up_to_date 2>/dev/null | sort -u | awk '{print $1}' | grep "^//" | tee $OUTPUT
+"$@" --test_summary=short --check_tests_up_to_date 2>/dev/null | sort -u | awk '{print $1}' | grep "^//" | tee $OUTPUT

--- a/tf_sig_build_dockerfiles/devel.usertools/preliminary_code_check.bats
+++ b/tf_sig_build_dockerfiles/devel.usertools/preliminary_code_check.bats
@@ -1,32 +1,36 @@
-changed_files() {
-    git diff --name-only origin/master
-    # get all changed targets...
-    bazel query $(git diff --name-only origin/master | sed ':a; N; $!ba; s/\n/ union /g') --keep_going
-}
-
+# This file is a work in progress, designed to replace the complicated test
+# orchestration previously placed in TensorFlow's ci_sanity.sh.
+# This is not currently in use.
 setup_file() {
     cd /tf/tensorflow
     bazel version  # Start the bazel server
+    git diff --name-only origin/master > $BATS_FILE_TMPDIR/changed_files
+    run bazel query $(git diff --name-only origin/master | sed ':a; N; $!ba; s/\n/ union /g') --keep_going > $BATS_FILE_TMPDIR/changed_targets || true
 }
 
-@test "Validate BUILD files" {
-    changed_files | xargs bazel query | xargs bazel query "attr('srcs', '{}'
-    bazel build --jobs=auto --nobuild -- //tensorflow/... -//tensorflow/lite/...
-    bazel query --noimplicit_deps -- 'deps(//tensorflow/...) - kind("android_*", //tensorflow/...)' > /dev/null
+@test "Run bazel nobuild on affected targets" {
+    xargs -a $BATS_FILE_TMPDIR/changed_targets bazel build --experimental_cc_shared_library --jobs=auto --nobuild --deleted_packages="" --
+}
+
+@test "Pip package smoke test" {
+    skip
+}
+
+@test "Check buildifier formatting on BUILD files" {
+    grep -e 'BUILD' $BATS_FILE_TMPDIR/changed_files | xargs buildifier -v -mode=diff -diff_command=diff
 }
 
 @test "Check formatting for C++ files" {
-    changed_files | grep -e '\.h$' -e '\.cc$' | xargs -I'{}' -n1 -P $(nproc --all) bash -c 'clang-format {} | diff - {} >/dev/null|| echo {}' | tee needs_help.txt
+    grep -e '\.h$' -e '\.cc$' $BATS_FILE_TMPDIR/changed_files | xargs -I'{}' -n1 -P $(nproc --all) bash -c 'clang-format {} | diff - {} >/dev/null|| echo {}' | tee needs_help.txt
     test ! -s needs_help.txt
 }
 
 @test "Check formatting for Python files" {
-    skip
-    pylint --rcfile=tensorflow/tools/ci_build/pylintrc -j $(nproc --all) $(git ls-files '*.py') --disable=all --enable=E,W0311,W0312,C0330,C0301,C0326,W0611,W0622
+    grep -e "\.py$" $BATS_FILE_TMPDIR/changed_files | xargs -I'{}' pylint --rcfile=tensorflow/tools/ci_build/pylintrc {} -j $(nproc --all) --disable=all --enable=E,W0311,W0312,C0330,C0301,C0326,W0611,W0622
 }
 
 @test "All tensorflow.org/code links point to real files" {
-    for i in `grep -onI 'https://www.tensorflow.org/code/[a-zA-Z0-9/._-]\+' -r tensorflow`; do
+    for i in $(grep -onI 'https://www.tensorflow.org/code/[a-zA-Z0-9/._-]\+' -r tensorflow); do
         target=$(echo $i | sed 's!.*https://www.tensorflow.org/code/!!g')
 
         if [[ ! -f $target ]] && [[ ! -d $target ]]; then
@@ -39,6 +43,16 @@ setup_file() {
             false
         fi
     done
+}
+
+@test "No identically-named files if ignoring casing" {
+    echo There are repeats of these filename(s) with different casing.
+    echo Please rename files so there are no repeats.
+    echo Rationale: for example, README.md and Readme.md would be the same file
+    echo            on windows. In this test, you would get a warning for
+    echo            "readme.md" because it checks by setting all to lowercase.
+    find . | tr '[A-Z]' '[a-z]' | sort | uniq -d | tee $BATS_FILE_TMPDIR/repeats
+    [[ ! -s $BATS_FILE_TMPDIR/repeats ]]
 }
 
 teardown_file() {

--- a/tf_sig_build_dockerfiles/devel.usertools/test.requirements.txt
+++ b/tf_sig_build_dockerfiles/devel.usertools/test.requirements.txt
@@ -1,6 +1,6 @@
 # Test dependencies for pip tests
 grpcio ~= 1.42.0
 portpicker ~= 1.4.0
-scipy ~= 1.5.4
-jax ~= 0.2.18
-jaxlib ~= 0.1.70
+scipy ~= 1.7.3
+jax ~= 0.2.26
+jaxlib ~= 0.1.75

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -33,23 +33,9 @@ ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
 
 # Install pip
-if [[ "$VERSION" == "python3.10" ]]; then
-  # In Python 3.10 with pip 21.3.x, get-pip.py does not install pip correctly.
-  # Therefore, we use "ensurepip" but do not upgrade pip afterwards. The version
-  # of pip included with ensurepip should work properly.
-  # See https://github.com/pypa/pip/issues/10647#issuecomment-967144347
-  # TODO(rameshsampath): Remove this version-specific workaround, either when
-  #   pip is fixed or when we find a method that works for all versions.
-  #   ensurepip does not work for the system python version (python 3.8 for 
-  #   Ubuntu 20.04); it wants "python3-pip" instead.
-  python3 -m ensurepip
-  # Create a symlink so that "pip" works as expected
-  ln --symbolic --force pip3 /usr/bin/pip
-else
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py
-  python3 -m pip install --no-cache-dir --upgrade pip
-fi
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+python3 -m pip install --no-cache-dir --upgrade pip
 
 # Disable the cache dir to save image space, and install packages
 python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -31,7 +31,13 @@ popd
 ln -sf /usr/bin/$VERSION /usr/bin/python3
 ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
-ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
+
+# Python 3.10 include headers fix:
+# sysconfig.get_path('include') incorrectly points to /usr/local/include/python
+# map /usr/include/python3.10 to /usr/local/include/python3.10
+if [[ -f "/usr/local/include/$VERSION" ]]; then
+  ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
+fi
 
 # Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -31,6 +31,7 @@ popd
 ln -sf /usr/bin/$VERSION /usr/bin/python3
 ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
+ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
 
 # Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -35,7 +35,7 @@ ln -sf /usr/lib/$VERSION /usr/lib/tf_python
 # Python 3.10 include headers fix:
 # sysconfig.get_path('include') incorrectly points to /usr/local/include/python
 # map /usr/include/python3.10 to /usr/local/include/python3.10
-if [[ -f "/usr/local/include/$VERSION" ]]; then
+if [[ ! -f "/usr/local/include/$VERSION" ]]; then
   ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
 fi
 


### PR DESCRIPTION
Issue: Python3.10 builds fail with error - 
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted: Analysis of target '@local_config_python//:python_include' failed

Fixes:
1. With the new python3.10.2, the need for special handling of pip install is not required.
2. Map /usr/include/python to /usr/local/include/python.  This is required for python 3.10 to link correctly.  Its a no-op for other python version.
when you run command - 
```
python -c "from __future__ import print_function;import sysconfig;print(sysconfig.get_path('include'))"
```
it points to `/usr/local/include/python3.10` whereas in other python versions it points correctly to `/usr/include/python3.9`.  The files are in `/usr/local/python3.10`, so its required to map `/usr/include/python3.10` to /usr/local/include/python3.10`

Testing:
Verified that with these changes the python 3.10 builds correctly by running the build locally using the staging docker container.

