### PR TITLE
Fix Build issue from `python_include`

### DIFF
--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -33,23 +33,9 @@ ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
 
 # Install pip
-if [[ "$VERSION" == "python3.10" ]]; then
-  # In Python 3.10 with pip 21.3.x, get-pip.py does not install pip correctly.
-  # Therefore, we use "ensurepip" but do not upgrade pip afterwards. The version
-  # of pip included with ensurepip should work properly.
-  # See https://github.com/pypa/pip/issues/10647#issuecomment-967144347
-  # TODO(rameshsampath): Remove this version-specific workaround, either when
-  #   pip is fixed or when we find a method that works for all versions.
-  #   ensurepip does not work for the system python version (python 3.8 for 
-  #   Ubuntu 20.04); it wants "python3-pip" instead.
-  python3 -m ensurepip
-  # Create a symlink so that "pip" works as expected
-  ln --symbolic --force pip3 /usr/bin/pip
-else
-  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py
-  python3 -m pip install --no-cache-dir --upgrade pip
-fi
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+python3 -m pip install --no-cache-dir --upgrade pip
 
 # Disable the cache dir to save image space, and install packages
 python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -31,7 +31,13 @@ popd
 ln -sf /usr/bin/$VERSION /usr/bin/python3
 ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
-ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
+
+# Python 3.10 include headers fix:
+# sysconfig.get_path('include') incorrectly points to /usr/local/include/python
+# map /usr/include/python3.10 to /usr/local/include/python3.10
+if [[ -f "/usr/local/include/$VERSION" ]]; then
+  ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
+fi
 
 # Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -31,6 +31,7 @@ popd
 ln -sf /usr/bin/$VERSION /usr/bin/python3
 ln -sf /usr/bin/$VERSION /usr/bin/python
 ln -sf /usr/lib/$VERSION /usr/lib/tf_python
+ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
 
 # Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tf_sig_build_dockerfiles/setup.python.sh
@@ -35,7 +35,7 @@ ln -sf /usr/lib/$VERSION /usr/lib/tf_python
 # Python 3.10 include headers fix:
 # sysconfig.get_path('include') incorrectly points to /usr/local/include/python
 # map /usr/include/python3.10 to /usr/local/include/python3.10
-if [[ -f "/usr/local/include/$VERSION" ]]; then
+if [[ ! -f "/usr/local/include/$VERSION" ]]; then
   ln -sf /usr/include/$VERSION /usr/local/include/$VERSION
 fi
 


### PR DESCRIPTION
Issue: Python3.10 builds fail with error - 
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted: Analysis of target '@local_config_python//:python_include' failed

Fixes:
1. With the new python3.10.2, the need for special handling of pip install is not required.
2. Map /usr/include/python to /usr/local/include/python.  This is required for python 3.10 to link correctly.  Its a no-op for other python version.
when you run command - 
```
python -c "from __future__ import print_function;import sysconfig;print(sysconfig.get_path('include'))"
```
it points to `/usr/local/include/python3.10` whereas in other python versions it points correctly to `/usr/include/python3.9`.  The files are in `/usr/local/python3.10`, so its required to map `/usr/include/python3.10` to /usr/local/include/python3.10`

Testing:
Verified that with these changes the python 3.10 builds correctly by running the build locally using the staging docker container.