### PR TITLE
Add openssh-client for git

### DIFF
--- a/manylinux2014_docker_images/install/install_deb_packages.sh
+++ b/manylinux2014_docker_images/install/install_deb_packages.sh
@@ -51,6 +51,7 @@ apt-get install -y --no-install-recommends \
     mlocate \
     openjdk-8-jdk \
     openjdk-8-jre-headless \
+    openssh-client \
     patchelf \
     pkg-config \
     python3-dev \


### PR DESCRIPTION
As we already install git this is required for git push operations in the container when you use this as a devel image.