### PR TITLE
Align abseil-py to TF

### DIFF
--- a/manylinux2014_docker_images/install/install_pip_packages.sh
+++ b/manylinux2014_docker_images/install/install_pip_packages.sh
@@ -62,7 +62,7 @@ $PYTHON_CMD -m pip install --upgrade six>=1.12.0
 $PYTHON_CMD -m pip install --upgrade future>=0.17.1
 
 # Install absl-py.
-$PYTHON_CMD -m pip install --upgrade absl-py
+$PYTHON_CMD -m pip install --upgrade absl-py==1.0.0
 
 # Install werkzeug.
 $PYTHON_CMD -m pip install --upgrade werkzeug==0.11.10


### PR DESCRIPTION
I suppose that we had some side effect with layer caching on build

```bash
docker run --rm -it  gcr.io/tensorflow-sigs/build:latest-python3.10 pip show absl-py | grep Version
Version: 0.13.0
```
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace2.bzl#L409

https://github.com/tensorflow/tensorflow/pull/52546#issuecomment-946985071
