### PR TITLE
Update LD_LIBRARY_PATH to cuda/lib directory

### DIFF
--- a/ppc64le_builds/scripts/gpu_build.sh
+++ b/ppc64le_builds/scripts/gpu_build.sh
@@ -16,7 +16,7 @@ build:xla --define with_xla_support=true
 build --config=xla
 build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda"
 build --action_env TF_CUDA_COMPUTE_CAPABILITIES="3.5,7.0"
-build --action_env LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+build --action_env LD_LIBRARY_PATH="/usr/local/cuda/lib:/usr/local/cuda/lib64"
 build --action_env GCC_HOST_COMPILER_PATH="/opt/rh/devtoolset-8/root/usr/bin/gcc"
 build --config=cuda
 build:opt --copt=-mcpu=power8


### PR DESCRIPTION
Docker image doesn't look like it has /usr/local/nvidia - 
```
tf-docker /tf/tensorflow > ls /usr/local/
bin/       cuda-11.1/ etc/       include/   libexec/   sbin/      src/
cuda/      cuda-11.2/ games/     lib/       man/       share/
```
So updating the LD_LIBRARY_PATH as suggested in https://github.com/NVIDIA/nvidia-docker/issues/789 and https://github.com/tensorflow/tensorflow/issues/55492

`/usr/local/cuda/lib64` seems to have the right .so files.