### PR TITLE
Update gpu.bazelrc

### DIFF
--- a/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -62,7 +62,7 @@ build --repo_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,com
 
 # Test-related settings below this point.
 test --build_tests_only --keep_going --test_output=errors --verbose_failures=true
-test --test_env=LD_LIBRARY_PATH
+test --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda-11.1/lib64"
 # Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
 test --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
 # Give only the list of failed tests at the end of the log


### PR DESCRIPTION
LD_LIBRARY_PATH is not set for the `bazel test` and defaults to `/usr/local/nvidia/lib:/usr/local/nvidia/lib64` causing test errors.

```
2022-04-28 09:28:15.414172: W 
tensorflow/stream_executor/platform/default/dso_loader.cc:64] 
Could not load dynamic library 'libnvinfer.so.7'; 
dlerror: libnvrtc.so.11.1: cannot open shared object file: No such file or directory; 
LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
```