### PR TITLE
Remove global setting of LD_LIBRARY_PATH

### DIFF
--- a/tf_sig_build_dockerfiles/Dockerfile
+++ b/tf_sig_build_dockerfiles/Dockerfile
@@ -21,10 +21,6 @@ RUN /build_devtoolset.sh devtoolset-9 /dt9
 ################################################################################
 FROM nvidia/cuda:11.2.2-base-ubuntu20.04 as devel
 ################################################################################
-# LD Library Path is not correctly set. It points to /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-RUN echo $LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda-11.1/lib64"
-
 COPY --from=builder /dt7 /dt7
 COPY --from=builder /dt9 /dt9
 


### PR DESCRIPTION
This change failed to capture the downstream effects of tensorflow installs on CPU that doesn't have the Cuda libraries. 

The smoke test failed to capture the effect correctly when importing tensorflow on systems that didn't have this global variable set.  
```
>>> import tensorflow as tf
```

Reverts PR #100 and #102 