### PR TITLE
[Go] Update Go API installation guide for TensorFlow 2.9.0

### DIFF
--- a/golang_install_guide/README.md
+++ b/golang_install_guide/README.md
@@ -36,7 +36,7 @@ library is required for use of the TensorFlow Go package at runtime. For example
 on Linux (64-bit, x86):
 
   ```sh
-  $ curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.8.0.tar.gz | tar xz --directory /usr/local
+  $ curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.9.0.tar.gz | tar xz --directory /usr/local
   $ ldconfig
   ```
 
@@ -74,7 +74,7 @@ Instead, follow these instructions.***
   workspace for `/go` in the command below.
 
   ```sh
-  $ git clone --branch v2.8.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
+  $ git clone --branch v2.9.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
   ```
 
 - Change the working directory to the base of the cloned TensorFlow repository,
@@ -83,12 +83,6 @@ Instead, follow these instructions.***
  
    ```sh
    $ cd /go/src/github.com/tensorflow/tensorflow
-   ```
-
-- Apply a required patch to the TensorFlow source code.
-
-   ```sh
-   $ git cherry-pick --strategy-option=no-renames --no-commit 65a5434
    ```
 
 - Initialize a new go.mod file.
@@ -127,7 +121,7 @@ workspace for `/go` in the command below:
 
 ```sh
 $ go mod init hello-world
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.8.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.9.0+incompatible
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy
 ```
@@ -173,7 +167,7 @@ func main() {
 
 ```sh
 $ go mod init app
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.8.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.9.0+incompatible
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy
 ```

--- a/golang_install_guide/example-program/Dockerfile
+++ b/golang_install_guide/example-program/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 # ============================================================================
 
 
-FROM golang:1.17-bullseye
+FROM golang:1.18-bullseye
 
-# 1. Install the TensorFlow C Library (v2.8.0).
-RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-2.8.0.tar.gz \
+# 1. Install the TensorFlow C Library (v2.9.0).
+RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-2.9.0.tar.gz \
     | tar xz --directory /usr/local \
     && ldconfig
 
@@ -27,9 +27,8 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     protobuf-compiler
 
 # 3. Install and Setup the TensorFlow Go API.
-RUN git clone --branch=v2.8.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
+RUN git clone --branch=v2.9.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
     && cd /go/src/github.com/tensorflow/tensorflow \
-    && git cherry-pick --strategy-option=no-renames --no-commit 65a5434 \
     && go mod init github.com/tensorflow/tensorflow \
     && (cd tensorflow/go/op && go generate) \
     && go mod tidy \
@@ -39,7 +38,7 @@ RUN git clone --branch=v2.8.0 https://github.com/tensorflow/tensorflow.git /go/s
 WORKDIR /example-program
 COPY hello_tf.go .
 RUN go mod init app \
-    && go mod edit -require github.com/tensorflow/tensorflow@v2.8.0+incompatible \
+    && go mod edit -require github.com/tensorflow/tensorflow@v2.9.0+incompatible \
     && go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow \
     && go mod tidy \
     && go build


### PR DESCRIPTION
PR updates Go install guide and Dockerfile in example for TF 2.9.0 release.