### PR TITLE
Pin pylint

### DIFF
--- a/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -52,4 +52,4 @@ twine ~= 3.6.0
 # For user tool scripts
 junitparser ~= 2.2.0
 lxml ~= 4.6.4
-pylint
+pylint ~= 2.13.9


### PR DESCRIPTION
All CI deps should be pinned both to prevent supply-chain attacks and also to prevent breakages caused by new version of deps.

In this case, we are preventing the second part, TF PRs are already blocked.