### PR TITLE
Bump lxml to latest release.

### DIFF
--- a/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -51,5 +51,5 @@ twine ~= 3.6.0
 
 # For user tool scripts
 junitparser ~= 2.2.0
-lxml ~= 4.6.4
+lxml ~= 4.9.1
 pylint ~= 2.13.9


### PR DESCRIPTION
There is a nullptr dereference in the previous versions. See https://nvd.nist.gov/vuln/detail/CVE-2022-2309