### PR TITLE
Add the OpenSSF Scorecard Github Action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@13ec8c77e8a5dae7e0a0d47bde3e3004df15d34f # tag=v2.0.0
+        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,54 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '44 22 * * 3'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@13ec8c77e8a5dae7e0a0d47bde3e3004df15d34f # tag=v2.0.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results. 
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Gitter chat](https://img.shields.io/badge/chat-on%20gitter-46bc99.svg)](https://gitter.im/tensorflow/sig-build)
 [![SIG Build Forum](https://img.shields.io/badge/discuss-on%20tensorflow.org-orange)](https://groups.google.com/a/tensorflow.org/g/build)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/joycebrum/build/badge)](https://api.securityscorecards.dev/projects/github.com/joycebrum/build)
 
 **TensorFlow SIG Build** is a community group dedicated to the TensorFlow build
 process. This repository is a showcase of resources, guides, tools, and builds

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Gitter chat](https://img.shields.io/badge/chat-on%20gitter-46bc99.svg)](https://gitter.im/tensorflow/sig-build)
 [![SIG Build Forum](https://img.shields.io/badge/discuss-on%20tensorflow.org-orange)](https://groups.google.com/a/tensorflow.org/g/build)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/joycebrum/build/badge)](https://api.securityscorecards.dev/projects/github.com/joycebrum/build)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tensorflow/build/badge)](https://api.securityscorecards.dev/projects/github.com/tensorflow/build)
 
 **TensorFlow SIG Build** is a community group dedicated to the TensorFlow build
 process. This repository is a showcase of resources, guides, tools, and builds


### PR DESCRIPTION
Closes #130 

### What I've done
I've created the configuration file to OpenSSF Scorecard Github Action (described in details in #130).

There’s also the optional [badge](https://openssf.org/blog/2022/09/08/show-off-your-security-score-announcing-scorecards-badges/) (which I've added to the README file) that can show your commitment to secure practices.  Besides, congratulations on the score, your project is in the top 18% of open source projects!

Any doubts or concerns please feel free to reach me out.
