### PR TITLE
[Go] Update Go API installation guide for TensorFlow 2.13.0

### DIFF
--- a/golang_install_guide/README.md
+++ b/golang_install_guide/README.md
@@ -48,8 +48,8 @@ repo, and with one of the following import statements:
 
 | TensorFlow C API          | Graft                                                                                               |
 | :------------------------ | :-------------------------------------------------------------------------------------------------- |
-| TensorFlow Release 2.12.0 | [`go get github.com/wamuir/graft/tensorflow@v0.4.0`](https://github.com/wamuir/graft/tree/v0.4.0)   |
-| TensorFlow Release 2.11.1 | [`go get github.com/wamuir/graft/tensorflow@v0.3.1`](https://github.com/wamuir/graft/tree/v0.3.1)   |
+| TensorFlow Release 2.13.0 | [`go get github.com/wamuir/graft/tensorflow@v0.5.0`](https://github.com/wamuir/graft/tree/v0.5.0)   |
+| TensorFlow Release 2.12.1 | [`go get github.com/wamuir/graft/tensorflow@v0.4.1`](https://github.com/wamuir/graft/tree/v0.4.1)   |
 | TensorFlow Nightly        | [`go get github.com/wamuir/graft/tensorflow@nightly`](https://github.com/wamuir/graft/tree/nightly) |
 
 
@@ -58,7 +58,7 @@ repo, and with one of the following import statements:
 <details>
 <summary>Click to expand</summary>
 
-> Note: these build instructions are specific to TensorFlow 2.12.0
+> Note: these build instructions are specific to TensorFlow 2.13.0
 
 ### 1. Install the TensorFlow C Library
 
@@ -67,7 +67,7 @@ library is required for use of the TensorFlow Go package at runtime. For example
 on Linux (64-bit, x86):
 
   ```sh
-  $ curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.12.0.tar.gz | tar xz --directory /usr/local
+  $ curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.13.0.tar.gz | tar xz --directory /usr/local
   $ ldconfig
   ```
 
@@ -105,7 +105,7 @@ Instead, follow these instructions.***
   workspace for `/go` in the command below.
 
   ```sh
-  $ git clone --branch v2.12.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
+  $ git clone --branch v2.13.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
   ```
 
 - Change the working directory to the base of the cloned TensorFlow repository,
@@ -126,8 +126,9 @@ Instead, follow these instructions.***
 
    ```sh
    $ sed -i '4 i option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/dataset_go_proto";' tensorflow/core/framework/dataset.proto
+   $ sed -i '9 c option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/graph_debug_info_go_proto";' tensorflow/core/framework/graph_debug_info.proto
    $ sed -i '4 i option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/optimized_function_graph_go_proto";' tensorflow/core/framework/optimized_function_graph.proto
-   $ sed -i '4 i option go_package = "github.com\/google\/tsl\/tsl\/go\/core\/protobuf\/for_core_protos_go_proto";;' tensorflow/tsl/protobuf/test_log.proto
+   $ sed -i '4 i option go_package = "github.com\/google\/tsl\/tsl\/go\/core\/protobuf\/for_core_protos_go_proto";' tensorflow/tsl/protobuf/test_log.proto
    ```
 
 - Patch tensorflow/go/genop to generate TF and TSL protobufs.
@@ -182,7 +183,7 @@ workspace for `/go` in the command below:
 ```sh
 $ go mod init hello-world
 $ go mod edit -require github.com/google/tsl@v0.0.0+incompatible
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.12.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.13.0+incompatible
 $ go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy
@@ -230,7 +231,7 @@ func main() {
 ```sh
 $ go mod init app
 $ go mod edit -require github.com/google/tsl@v0.0.0+incompatible
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.12.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.13.0+incompatible
 $ go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy

--- a/golang_install_guide/example-program/Dockerfile
+++ b/golang_install_guide/example-program/Dockerfile
@@ -14,10 +14,10 @@
 # ============================================================================
 
 
-FROM golang:1.20-bullseye
+FROM golang:1.20-bookworm
 
-# 1. Install the TensorFlow C Library (v2.12.0).
-RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-2.12.0.tar.gz \
+# 1. Install the TensorFlow C Library (v2.13.0).
+RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-2.13.0.tar.gz \
     | tar xz --directory /usr/local \
     && ldconfig
 
@@ -27,12 +27,13 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     protobuf-compiler
 
 # 3. Install and Setup the TensorFlow Go API.
-RUN git clone --branch=v2.12.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
+RUN git clone --branch=v2.13.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
     && cd /go/src/github.com/tensorflow/tensorflow \
     && go mod init github.com/tensorflow/tensorflow \
     && sed -i '4 i option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/dataset_go_proto";' tensorflow/core/framework/dataset.proto \
+    && sed -i '9 c option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/graph_debug_info_go_proto";' tensorflow/core/framework/graph_debug_info.proto \
     && sed -i '4 i option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/optimized_function_graph_go_proto";' tensorflow/core/framework/optimized_function_graph.proto \
-    && sed -i '4 i option go_package = "github.com\/google\/tsl\/tsl\/go\/core\/protobuf\/for_core_protos_go_proto";;' tensorflow/tsl/protobuf/test_log.proto \
+    && sed -i '4 i option go_package = "github.com\/google\/tsl\/tsl\/go\/core\/protobuf\/for_core_protos_go_proto";' tensorflow/tsl/protobuf/test_log.proto \
     && sed -i '71d;72d' tensorflow/go/genop/generate.sh \
     && sed -i '71 i \    ${TF_DIR}\/tensorflow\/tsl\/protobuf\/*.proto \\' tensorflow/go/genop/generate.sh \
     && sed -i '72 i \    ${TF_DIR}\/tensorflow\/compiler\/xla\/stream_executor\/dnn.proto; do' tensorflow/go/genop/generate.sh \
@@ -48,7 +49,7 @@ WORKDIR /example-program
 COPY hello_tf.go .
 RUN go mod init app \
     && go mod edit -require github.com/google/tsl@v0.0.0+incompatible \
-    && go mod edit -require github.com/tensorflow/tensorflow@v2.12.0+incompatible \
+    && go mod edit -require github.com/tensorflow/tensorflow@v2.13.0+incompatible \
     && go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl \
     && go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow \
     && go mod tidy \


### PR DESCRIPTION
PR updates Go install guide and Dockerfile in example for TF 2.13.0 release.

cc: @angerson
