### PR TITLE
Revert change of testing logic in gpu.Dockerfile

### DIFF
--- a/tensorflow_runtime_dockerfiles/gpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/gpu.Dockerfile
@@ -52,5 +52,5 @@ CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/
 FROM base as test
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH
-COPY test.import_gpu.sh /test.import_gpu.sh
-RUN /test.import_gpu.sh
+COPY test.import_cpu.sh /test.import_cpu.sh
+RUN /test.import_cpu.sh


### PR DESCRIPTION
The nightly build machines don't have a GPU, so this test fails and Docker images are not getting uploaded.

Reverting the change from #165 should fix it for now.