### PR TITLE
Promote ARM64 to a TF Official Continous

### DIFF
--- a/tf_oss_dashboard/tensorflow.yaml
+++ b/tf_oss_dashboard/tensorflow.yaml
@@ -30,6 +30,8 @@ categories:
     - Continuous - Linux x86 CPU - Py+CPP Test Suite (minimum Python version)
     - Continuous - Linux x86 CUDA - Py+CPP Test Suite (maximum Python version)
     - Continuous - Linux x86 CUDA - Py+CPP Test Suite (minimum Python version)
+    - Continuous - Linux arm64 CPU - Py+CPP Test Suite (maximum Python version)
+    - Continuous - Linux arm64 CPU - Py+CPP Test Suite (minimum Python version)
     - Continuous - MacOS x86 - Py+CPP Test Suite (maximum Python version)
     - Continuous - MacOS x86 - Py+CPP Test Suite (minimum Python version)
   TF Official Nightly:


### PR DESCRIPTION
Will be merged in the near future as TF DevInfra promotes the arm64 builds to have internal build monitoring 