### PR TITLE
[Go] Update Go API installation guide for TensorFlow 2.16.1

### DIFF
--- a/golang_install_guide/README.md
+++ b/golang_install_guide/README.md
@@ -48,8 +48,8 @@ repo, and with one of the following import statements:
 
 | TensorFlow C API          | Graft                                                                                               |
 | :------------------------ | :-------------------------------------------------------------------------------------------------- |
+| TensorFlow Release 2.16.1 | [`go get github.com/wamuir/graft/tensorflow@v0.8.0`](https://github.com/wamuir/graft/tree/v0.8.0)   |
 | TensorFlow Release 2.15.0 | [`go get github.com/wamuir/graft/tensorflow@v0.7.0`](https://github.com/wamuir/graft/tree/v0.7.0)   |
-| TensorFlow Release 2.14.1 | [`go get github.com/wamuir/graft/tensorflow@v0.6.1`](https://github.com/wamuir/graft/tree/v0.6.1)   |
 | TensorFlow Nightly        | [`go get github.com/wamuir/graft/tensorflow@nightly`](https://github.com/wamuir/graft/tree/nightly) |
 
 
@@ -58,7 +58,7 @@ repo, and with one of the following import statements:
 <details>
 <summary>Click to expand</summary>
 
-> Note: these build instructions are specific to TensorFlow 2.15.0
+> Note: these build instructions are specific to TensorFlow 2.16.1
 
 ### 1. Install the TensorFlow C Library
 
@@ -67,7 +67,7 @@ library is required for use of the TensorFlow Go package at runtime. For example
 on Linux (64-bit, x86):
 
   ```sh
-  $ curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.15.0.tar.gz | tar xz --directory /usr/local
+  $ curl -L https://storage.googleapis.com/tensorflow/versions/2.16.1/libtensorflow-cpu-linux-x86_64.tar.gz | tar xz --directory /usr/local
   $ ldconfig
   ```
 
@@ -105,7 +105,7 @@ Instead, follow these instructions.***
   workspace for `/go` in the command below.
 
   ```sh
-  $ git clone --branch v2.15.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
+  $ git clone --branch v2.16.1 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow
   ```
 
 - Change the working directory to the base of the cloned TensorFlow repository,
@@ -199,7 +199,7 @@ workspace for `/go` in the command below:
 ```sh
 $ go mod init hello-world
 $ go mod edit -require github.com/google/tsl@v0.0.0+incompatible
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.15.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.16.1+incompatible
 $ go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy
@@ -247,7 +247,7 @@ func main() {
 ```sh
 $ go mod init app
 $ go mod edit -require github.com/google/tsl@v0.0.0+incompatible
-$ go mod edit -require github.com/tensorflow/tensorflow@v2.15.0+incompatible
+$ go mod edit -require github.com/tensorflow/tensorflow@v2.16.1+incompatible
 $ go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl
 $ go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow
 $ go mod tidy

--- a/golang_install_guide/example-program/Dockerfile
+++ b/golang_install_guide/example-program/Dockerfile
@@ -14,10 +14,10 @@
 # ============================================================================
 
 
-FROM golang:1.21-bookworm
+FROM golang:1.22-bookworm
 
-# 1. Install the TensorFlow C Library (v2.15.0).
-RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-2.15.0.tar.gz \
+# 1. Install the TensorFlow C Library (v2.16.1).
+RUN curl -L https://storage.googleapis.com/tensorflow/versions/2.16.1/libtensorflow-cpu-linux-$(uname -m).tar.gz \
     | tar xz --directory /usr/local \
     && ldconfig
 
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     protobuf-compiler
 
 # 3. Install and Setup the TensorFlow Go API.
-RUN git clone --branch=v2.15.0 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
+RUN git clone --branch=v2.16.1 https://github.com/tensorflow/tensorflow.git /go/src/github.com/tensorflow/tensorflow \
     && cd /go/src/github.com/tensorflow/tensorflow \
     && go mod init github.com/tensorflow/tensorflow \
     && sed -i '4 i option go_package = "github.com\/tensorflow\/tensorflow\/tensorflow\/go\/core\/framework\/dataset_go_proto";' tensorflow/core/framework/dataset.proto \
@@ -60,7 +60,7 @@ WORKDIR /example-program
 COPY hello_tf.go .
 RUN go mod init app \
     && go mod edit -require github.com/google/tsl@v0.0.0+incompatible \
-    && go mod edit -require github.com/tensorflow/tensorflow@v2.15.0+incompatible \
+    && go mod edit -require github.com/tensorflow/tensorflow@v2.16.1+incompatible \
     && go mod edit -replace github.com/google/tsl=/go/src/github.com/google/tsl \
     && go mod edit -replace github.com/tensorflow/tensorflow=/go/src/github.com/tensorflow/tensorflow \
     && go mod tidy \


### PR DESCRIPTION
PR updates Go install guide and Dockerfile in example for TF 2.16.1 release.