### PR TITLE
resolve issue #176

### DIFF
--- a/tensorflow_runtime_dockerfiles/build_images.sh
+++ b/tensorflow_runtime_dockerfiles/build_images.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#
+# build the CPU images
+#
+docker build --target=jupyter \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-cpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-cpu -f cpu.Dockerfile .
+
+docker build --target=test \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-cpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-cpu-test -f cpu.Dockerfile .
+
+#
+# build the GPU images
+#
+docker build --target=jupyter \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-gpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-gpu -f gpu.Dockerfile .
+
+docker build --target=test \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-gpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-gpu-test -f cpu.Dockerfile .
+
+#
+# build the TPU images
+#
+docker build --target=jupyter \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-tpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-tpu -f cpu.Dockerfile .
+
+docker build --target=test \
+    --build-arg TENSORFLOW_PACKAGE=tf-nightly-tpu \
+    --build-arg TENSORFLOW_USER=tf \
+    --build-arg TENSORFLOW_GROUP=tfuser \
+    --build-arg TENSORFLOW_UID=2024 \
+    --build-arg TENSORFLOW_GID=2024 \
+    -t tensorflow-nightly-tpu-test -f cpu.Dockerfile .

--- a/tensorflow_runtime_dockerfiles/cpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/cpu.Dockerfile
@@ -77,5 +77,5 @@ CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=$
 
 FROM base as test
 
-COPY test.import_cpu.sh /test.import_cpu.sh
+COPY --chown=${TENSORFLOW_USER}:${TENSORFLOW_GROUP} test.import_cpu.sh /test.import_cpu.sh
 RUN /test.import_cpu.sh

--- a/tensorflow_runtime_dockerfiles/cpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/cpu.Dockerfile
@@ -26,7 +26,15 @@ RUN /setup.packages.sh /cpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly
-ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ARG TENSORFLOW_USER=tfuser
+ARG TENSORFLOW_GROUP=tensorflow
+ARG TENSORFLOW_UID=2234
+ARG TENSORFLOW_GID=5567
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/${TENSORFLOW_USER}/notebooks
+ENV TENSORFLOW_USER=${TENSORFLOW_USER}
+ENV TENSORFLOW_GROUP=${TENSORFLOW_GROUP}
+ENV TENSORFLOW_UID=${TENSORFLOW_UID}
+ENV TENSORFLOW_GID=${TENSORFLOW_GID}
 ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY cpu.requirements.txt /cpu.requirements.txt
@@ -43,6 +51,10 @@ COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
 COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
+
+COPY setup.tensorflow.user.sh /setup.tensorflow.user.sh
+RUN /setup.tensorflow.user.sh
+RUN chown -R ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} ${TENSORFLOW_NOTEBOOK_DIR} /home/${TENSORFLOW_USER}
 
 WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888

--- a/tensorflow_runtime_dockerfiles/cpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/cpu.Dockerfile
@@ -26,6 +26,8 @@ RUN /setup.packages.sh /cpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY cpu.requirements.txt /cpu.requirements.txt
 RUN /setup.python.sh $PYTHON_VERSION /cpu.requirements.txt
@@ -40,12 +42,12 @@ COPY jupyter.requirements.txt /jupyter.requirements.txt
 COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
-COPY jupyter.readme.md /tf/tensorflow-tutorials/README.md
+COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
 
-WORKDIR /tf
+WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888
 
-CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]
+CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=${TENSORFLOW_NOTEBOOK_DIR} --ip 0.0.0.0 --no-browser --allow-root"]
 
 FROM base as test
 

--- a/tensorflow_runtime_dockerfiles/gpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/gpu.Dockerfile
@@ -25,7 +25,15 @@ RUN /setup.packages.sh /gpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly
-ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ARG TENSORFLOW_USER=tfuser
+ARG TENSORFLOW_GROUP=tensorflow
+ARG TENSORFLOW_UID=2234
+ARG TENSORFLOW_GID=5567
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/${TENSORFLOW_USER}/notebooks
+ENV TENSORFLOW_USER=${TENSORFLOW_USER}
+ENV TENSORFLOW_GROUP=${TENSORFLOW_GROUP}
+ENV TENSORFLOW_UID=${TENSORFLOW_UID}
+ENV TENSORFLOW_GID=${TENSORFLOW_GID}
 ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY gpu.requirements.txt /gpu.requirements.txt
@@ -45,6 +53,10 @@ COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
 COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
+
+COPY setup.tensorflow.user.sh /setup.tensorflow.user.sh
+RUN /setup.tensorflow.user.sh
+RUN chown -R ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} ${TENSORFLOW_NOTEBOOK_DIR} /home/${TENSORFLOW_USER}
 
 WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888

--- a/tensorflow_runtime_dockerfiles/gpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/gpu.Dockerfile
@@ -25,6 +25,8 @@ RUN /setup.packages.sh /gpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY gpu.requirements.txt /gpu.requirements.txt
 RUN /setup.python.sh $PYTHON_VERSION /gpu.requirements.txt
@@ -42,12 +44,12 @@ COPY jupyter.requirements.txt /jupyter.requirements.txt
 COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
-COPY jupyter.readme.md /tf/tensorflow-tutorials/README.md
+COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
 
-WORKDIR /tf
+WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888
 
-CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]
+CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=${TENSORFLOW_NOTEBOOK_DIR} --ip 0.0.0.0 --no-browser --allow-root"]
 
 FROM base as test
 

--- a/tensorflow_runtime_dockerfiles/setup.jupyter.sh
+++ b/tensorflow_runtime_dockerfiles/setup.jupyter.sh
@@ -7,8 +7,7 @@ mkdir -p -v ${TENSORFLOW_TUTORIALS}
 chmod -R a+rwx ${TENSORFLOW_NOTEBOOK_DIR}
 mkdir /.local
 chmod a+rwx /.local
-apt-get update
-apt-get install -y --no-install-recommends wget git
+
 cd ${TENSORFLOW_TUTORIALS}
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -16,8 +15,5 @@ wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/save_and_load.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
-
-apt-get autoremove -y
-apt-get remove -y wget
 
 python3 -m ipykernel.kernelspec

--- a/tensorflow_runtime_dockerfiles/setup.jupyter.sh
+++ b/tensorflow_runtime_dockerfiles/setup.jupyter.sh
@@ -4,10 +4,6 @@ jupyter serverextension enable --py jupyter_http_over_ws
 TENSORFLOW_TUTORIALS="${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials"
 mkdir -p -v ${TENSORFLOW_TUTORIALS}
 
-chmod -R a+rwx ${TENSORFLOW_NOTEBOOK_DIR}
-mkdir /.local
-chmod a+rwx /.local
-
 cd ${TENSORFLOW_TUTORIALS}
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
@@ -16,4 +12,6 @@ wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/text_classification_with_hub.ipynb
 
-python3 -m ipykernel.kernelspec
+
+python3 -m ipykernel install --user
+python3 -m ipykernel.kernelspec --user

--- a/tensorflow_runtime_dockerfiles/setup.jupyter.sh
+++ b/tensorflow_runtime_dockerfiles/setup.jupyter.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 jupyter serverextension enable --py jupyter_http_over_ws
 
-mkdir -p /tf/tensorflow-tutorials
-chmod -R a+rwx /tf/
+TENSORFLOW_TUTORIALS="${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials"
+mkdir -p -v ${TENSORFLOW_TUTORIALS}
+
+chmod -R a+rwx ${TENSORFLOW_NOTEBOOK_DIR}
 mkdir /.local
 chmod a+rwx /.local
 apt-get update
 apt-get install -y --no-install-recommends wget git
-cd /tf/tensorflow-tutorials
+cd ${TENSORFLOW_TUTORIALS}
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/overfit_and_underfit.ipynb
 wget https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/regression.ipynb

--- a/tensorflow_runtime_dockerfiles/setup.packages.sh
+++ b/tensorflow_runtime_dockerfiles/setup.packages.sh
@@ -23,6 +23,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
+apt-get install -y --no-install-recommends wget git
 
 # Remove commented lines and blank lines from the package list
 apt-get install -y --no-install-recommends $(sed -e '/^\s*#.*$/d' -e '/^\s*$/d' "$1" | sort -u)

--- a/tensorflow_runtime_dockerfiles/setup.tensorflow.user.sh
+++ b/tensorflow_runtime_dockerfiles/setup.tensorflow.user.sh
@@ -20,6 +20,6 @@
 #
 
 echo "creating group ${TENSORFLOW_GROUP} with gid ${TENSORFLOW_GID} ..." && \
-groupadd --system --gid ${TENSORFLOW_GID} ${TF_GROUP} && \
+groupadd --system --gid ${TENSORFLOW_GID} ${TENSORFLOW_GROUP} && \
 echo "creating user ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} (${TENSORFLOW_UID}:${TENSORFLOW_GID}) ..." && \
 useradd --system --uid ${TENSORFLOW_UID} --home-dir=/home/${TENSORFLOW_USER} --create-home --gid ${TENSORFLOW_GID} ${TENSORFLOW_USER}

--- a/tensorflow_runtime_dockerfiles/setup.tensorflow.user.sh
+++ b/tensorflow_runtime_dockerfiles/setup.tensorflow.user.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# setup.tensorflow.user.sh: create an user account used to run tensorflow
+# Usage: set envrionment variables TENSORFLOW_USER, TENSORFLOW_GROUP, TENSORFLOW_UID, TENSORFLOW_GID and run script setup.tensorflow.user.sh
+#
+
+echo "creating group ${TENSORFLOW_GROUP} with gid ${TENSORFLOW_GID} ..." && \
+groupadd --system --gid ${TENSORFLOW_GID} ${TF_GROUP} && \
+echo "creating user ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} (${TENSORFLOW_UID}:${TENSORFLOW_GID}) ..." && \
+useradd --system --uid ${TENSORFLOW_UID} --home-dir=/home/${TENSORFLOW_USER} --create-home --gid ${TENSORFLOW_GID} ${TENSORFLOW_USER}

--- a/tensorflow_runtime_dockerfiles/tpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/tpu.Dockerfile
@@ -20,7 +20,9 @@ ENV LANG C.UTF-8
 COPY setup.sources.sh /setup.sources.sh
 COPY setup.packages.sh /setup.packages.sh
 COPY tpu.packages.txt /tpu.packages.txt
+# set up apt sources (must be done as root):
 RUN /setup.sources.sh
+# install required packages (must be done as root):
 RUN /setup.packages.sh /tpu.packages.txt
 
 
@@ -38,23 +40,33 @@ ENV TENSORFLOW_GID=${TENSORFLOW_GID}
 ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY cpu.requirements.txt /tpu.requirements.txt
+# install python (must be done as root):
 RUN /setup.python.sh $PYTHON_VERSION /tpu.requirements.txt
-RUN pip install --no-cache-dir ${TENSORFLOW_PACKAGE} -f https://storage.googleapis.com/libtpu-tf-releases/index.html 
-
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
+# create and setup user ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} (must be done as root):
+COPY setup.tensorflow.user.sh /setup.tensorflow.user.sh
+RUN /setup.tensorflow.user.sh && \
+    mkdir -p /home/${TENSORFLOW_USER}/.local && \
+    chown -R ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} /home/${TENSORFLOW_USER}/.local
+ENV PATH="${PATH}:/home/${TENSORFLOW_USER}/.local/bin"
+
+# the rest of the commands is run by TENSORFLOW_USER
+USER ${TENSORFLOW_USER}
+
+RUN pip install --no-cache-dir ${TENSORFLOW_PACKAGE} -f https://storage.googleapis.com/libtpu-tf-releases/index.html 
 
 FROM base as jupyter
 
-COPY jupyter.requirements.txt /jupyter.requirements.txt
-COPY setup.jupyter.sh /setup.jupyter.sh
+USER ${TENSORFLOW_USER}
+# install and setup jupyter (should be done as TENSORFLOW_USER):
+COPY --chown=${TENSORFLOW_USER}:${TENSORFLOW_GROUP} jupyter.requirements.txt /jupyter.requirements.txt
+COPY --chown=${TENSORFLOW_USER}:${TENSORFLOW_GROUP} setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
-COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
+COPY --chown=${TENSORFLOW_USER}:${TENSORFLOW_GROUP} jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
 
-COPY setup.tensorflow.user.sh /setup.tensorflow.user.sh
-RUN /setup.tensorflow.user.sh
-RUN chown -R ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} ${TENSORFLOW_NOTEBOOK_DIR} /home/${TENSORFLOW_USER}
+
 
 WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888
@@ -63,5 +75,5 @@ CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=$
 
 FROM base as test
 
-COPY test.import_tpu.sh /test.import_tpu.sh
+COPY --chown=${TENSORFLOW_USER}:${TENSORFLOW_GROUP} test.import_tpu.sh /test.import_tpu.sh
 RUN /test.import_tpu.sh

--- a/tensorflow_runtime_dockerfiles/tpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/tpu.Dockerfile
@@ -26,7 +26,15 @@ RUN /setup.packages.sh /tpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly-tpu
-ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ARG TENSORFLOW_USER=tfuser
+ARG TENSORFLOW_GROUP=tensorflow
+ARG TENSORFLOW_UID=2234
+ARG TENSORFLOW_GID=5567
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/${TENSORFLOW_USER}/notebooks
+ENV TENSORFLOW_USER=${TENSORFLOW_USER}
+ENV TENSORFLOW_GROUP=${TENSORFLOW_GROUP}
+ENV TENSORFLOW_UID=${TENSORFLOW_UID}
+ENV TENSORFLOW_GID=${TENSORFLOW_GID}
 ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY cpu.requirements.txt /tpu.requirements.txt
@@ -43,6 +51,10 @@ COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
 COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
+
+COPY setup.tensorflow.user.sh /setup.tensorflow.user.sh
+RUN /setup.tensorflow.user.sh
+RUN chown -R ${TENSORFLOW_USER}:${TENSORFLOW_GROUP} ${TENSORFLOW_NOTEBOOK_DIR} /home/${TENSORFLOW_USER}
 
 WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888

--- a/tensorflow_runtime_dockerfiles/tpu.Dockerfile
+++ b/tensorflow_runtime_dockerfiles/tpu.Dockerfile
@@ -26,6 +26,8 @@ RUN /setup.packages.sh /tpu.packages.txt
 
 ARG PYTHON_VERSION=python3.11
 ARG TENSORFLOW_PACKAGE=tf-nightly-tpu
+ARG TENSORFLOW_NOTEBOOK_DIR=/home/tf_user/notebooks
+ENV TENSORFLOW_NOTEBOOK_DIR=${TENSORFLOW_NOTEBOOK_DIR}
 COPY setup.python.sh /setup.python.sh
 COPY cpu.requirements.txt /tpu.requirements.txt
 RUN /setup.python.sh $PYTHON_VERSION /tpu.requirements.txt
@@ -40,12 +42,12 @@ COPY jupyter.requirements.txt /jupyter.requirements.txt
 COPY setup.jupyter.sh /setup.jupyter.sh
 RUN python3 -m pip install --no-cache-dir -r /jupyter.requirements.txt -U
 RUN /setup.jupyter.sh
-COPY jupyter.readme.md /tf/tensorflow-tutorials/README.md
+COPY jupyter.readme.md ${TENSORFLOW_NOTEBOOK_DIR}/tensorflow-tutorials/README.md
 
-WORKDIR /tf
+WORKDIR ${TENSORFLOW_NOTEBOOK_DIR}
 EXPOSE 8888
 
-CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root"]
+CMD ["bash", "-c", "source /etc/bash.bashrc && jupyter notebook --notebook-dir=${TENSORFLOW_NOTEBOOK_DIR} --ip 0.0.0.0 --no-browser --allow-root"]
 
 FROM base as test
 


### PR DESCRIPTION
The entire installation of jupyter and tensorflow is done as user
${TENSORFLOW_USER} with pip. Folder /home/${TENSORFLOW_USER}/.local/bin
is added to the environment variable PATH. A notebook folder
/home/${TENSORFLOW_USER}/notebooks is created and the tutorials
are installed in this folder.

Finally the command

	source /etc/bash.bashrc && jupyter notebook --notebook-dir=${TENSORFLOW_NOTEBOOK_DIR} --ip 0.0.0.0 --no-browser --allow-root

is run as TENSORFLOW_USER.

The only thing still bothering me is the call to ldconfig in /etc/bash.bashrc.
I don't understand why we need this. And it can't be done as non-root user.